### PR TITLE
Fix numeric values serialized as quoted strings in YAML export

### DIFF
--- a/src/lib/yamlValidation.ts
+++ b/src/lib/yamlValidation.ts
@@ -3,6 +3,7 @@
  */
 
 import yaml from 'js-yaml';
+import { coerceYamlValues } from './export';
 
 export interface YamlValidationResult {
   isValid: boolean;
@@ -120,7 +121,7 @@ export function validateYamlContent(content: string): YamlValidationResult {
   // Re-serialize to ensure clean output (removes any potential exploits)
   try {
     const sanitizedContent = parsedDocuments
-      .map(doc => yaml.dump(doc, {
+      .map(doc => yaml.dump(coerceYamlValues(doc), {
         noRefs: true,
         sortKeys: false,
         lineWidth: -1,


### PR DESCRIPTION
## Summary
- Add `coerceYamlValues()` utility that recursively converts string values to their natural YAML types (number, boolean, null) before `yaml.dump()`
- Apply in `exportToYaml()`, `exportToKustomize()`, and `validateYamlContent()` sanitization
- Fixes fields like `replicas`, `containerPort`, `port`, `targetPort` being output as `'1'` instead of `1`, which causes `kubectl apply` validation errors

## Test plan
- [ ] `npm run build:lib` passes
- [ ] Exported YAML produces `replicas: 1` not `replicas: '1'`
- [ ] Boolean and null values also coerced correctly