### PR TITLE
Add smart field classification and educational guidance

### DIFF
--- a/src/components/flow/flow.contextmenu.component.tsx
+++ b/src/components/flow/flow.contextmenu.component.tsx
@@ -66,6 +66,22 @@ export default function ContextMenu({
                         View Issues
                     </button>
                     <button
+                        onClick={() => {
+                            const node = getNode(id);
+                            const current = !!(node?.data?.showReadOnlyFields);
+                            setNodes((nodes) =>
+                                nodes.map((n) =>
+                                    n.id === id
+                                        ? { ...n, data: { ...n.data, showReadOnlyFields: !current } }
+                                        : n
+                                )
+                            );
+                        }}
+                        className="w-full text-left px-3 py-1.5 text-xs hover:bg-brand-muted hover:text-brand transition-colors cursor-pointer"
+                    >
+                        {getNode(id)?.data?.showReadOnlyFields ? 'Hide Read-Only Fields' : 'Show Read-Only Fields'}
+                    </button>
+                    <button
                         onClick={deleteNode}
                         className="w-full text-left px-3 py-1.5 text-xs hover:bg-red-500/10 hover:text-red-600 dark:hover:text-red-400 transition-colors cursor-pointer"
                     >

--- a/src/components/flow/nodes/fields/field.classification-indicator.component.tsx
+++ b/src/components/flow/nodes/fields/field.classification-indicator.component.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { Lock } from "lucide-react"
+import type { FieldClassification } from "@/lib/schema/fieldClassification"
+
+interface ClassificationIndicatorProps {
+    classification: FieldClassification
+}
+
+export const ClassificationIndicator = ({ classification }: ClassificationIndicatorProps) => {
+    switch (classification) {
+        case 'required':
+            return <span className="inline-block w-1.5 h-1.5 rounded-full bg-red-500 shrink-0" />
+        case 'recommended':
+            return <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-500 shrink-0" />
+        case 'readOnly':
+            return <Lock className="w-2.5 h-2.5 text-muted-foreground/50 shrink-0" />
+        default:
+            return null
+    }
+}

--- a/src/components/flow/nodes/fields/field.config-refactored.component.tsx
+++ b/src/components/flow/nodes/fields/field.config-refactored.component.tsx
@@ -18,6 +18,8 @@ export const ConfigFieldRefactored = ({
     edges,
     mode = 'kind',
     readOnly = false,
+    classification,
+    parentPath,
     onRemove,
     depth = 0
 }: BaseFieldProps) => {
@@ -106,15 +108,20 @@ export const ConfigFieldRefactored = ({
     const depthBorder = depth > 0 ? 'border border-border' : ''
     const branchTick = depth > 0 ? 'relative before:absolute before:left-[-13px] before:top-1/2 before:w-[12px] before:h-px before:bg-border' : ''
 
+    const readOnlyOpacity = classification === 'readOnly' ? 'opacity-60' : ''
+
     if (isComplex && isComplexFieldResult(fieldResult)) {
         // For complex types with separate inline/expanded content
         return (
-            <div data-field-path={path} className={`${depthBg} ${depthBorder} ${branchTick} rounded ${depth > 0 ? 'p-2' : 'px-1'}`}>
+            <div data-field-path={path} className={`${depthBg} ${depthBorder} ${branchTick} ${readOnlyOpacity} rounded ${depth > 0 ? 'p-2' : 'px-1'}`}>
                 <div className="group/field relative flex items-center gap-1.5 min-h-8 pl-1">
                     <FieldLabel
                         label={label}
                         schema={schema}
                         isComplex={isComplex}
+                        classification={classification}
+                        kind={kind}
+                        parentPath={parentPath}
                     />
                     {fieldResult.inlineContent}
                     {removeButton}
@@ -125,12 +132,15 @@ export const ConfigFieldRefactored = ({
     } else {
         // For simple types, use the flex row layout
         return (
-            <div data-field-path={path} className={`space-y-1 ${depth > 0 ? `${depthBg} ${depthBorder} ${branchTick} rounded p-2` : ''}`}>
+            <div data-field-path={path} className={`space-y-1 ${readOnlyOpacity} ${depth > 0 ? `${depthBg} ${depthBorder} ${branchTick} rounded p-2` : ''}`}>
                 <div className="group/field relative flex items-center gap-2 min-h-8 pl-1">
                     <FieldLabel
                         label={label}
                         schema={schema}
                         isComplex={isComplex}
+                        classification={classification}
+                        kind={kind}
+                        parentPath={parentPath}
                     />
                     {fieldResult as React.ReactNode}
                     {removeButton}

--- a/src/components/flow/nodes/fields/field.label.component.tsx
+++ b/src/components/flow/nodes/fields/field.label.component.tsx
@@ -2,24 +2,48 @@
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { Schema } from "@/types"
+import type { FieldClassification } from "@/lib/schema/fieldClassification"
+import { getFieldEducation } from "@/lib/schema/fieldClassification"
+import { ClassificationIndicator } from "./field.classification-indicator.component"
 
 interface FieldLabelProps {
     label: string
     schema: Schema
     isComplex?: boolean
+    classification?: FieldClassification
+    kind?: string
+    parentPath?: string
 }
 
-export const FieldLabel = ({ label, schema, isComplex = false }: FieldLabelProps) => {
+export const FieldLabel = ({ label, schema, isComplex = false, classification, kind, parentPath }: FieldLabelProps) => {
+    const education = kind && classification === 'recommended' ? getFieldEducation(label, kind, parentPath) : null
+    const hasTooltipContent = schema?.description || education
+
+    const dimClass = classification === 'optional'
+        ? 'text-muted-foreground/50'
+        : classification === 'readOnly'
+            ? 'text-muted-foreground/50 italic'
+            : 'text-muted-foreground'
+
     return (
         <Tooltip>
             <TooltipTrigger asChild>
-                <span className={`text-xs text-muted-foreground shrink-0 ${isComplex ? 'order-1' : ''}`}>
+                <span className={`inline-flex items-center gap-1 text-xs ${dimClass} shrink-0 ${isComplex ? 'order-1' : ''}`}>
                     {label}
+                    {classification && <ClassificationIndicator classification={classification} />}
                 </span>
             </TooltipTrigger>
-            {schema?.description && (
+            {hasTooltipContent && (
                 <TooltipContent className="max-w-xs">
-                    {schema.description}
+                    <div className="space-y-1.5">
+                        {schema?.description && <p>{schema.description}</p>}
+                        {education && (
+                            <div className="border-t border-border pt-1.5">
+                                <p className="text-amber-500 text-[10px] font-semibold uppercase tracking-wide mb-0.5">Why this matters</p>
+                                <p className="text-xs">{education}</p>
+                            </div>
+                        )}
+                    </div>
                 </TooltipContent>
             )}
         </Tooltip>

--- a/src/components/flow/nodes/fields/field.section-header.component.tsx
+++ b/src/components/flow/nodes/fields/field.section-header.component.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { ChevronDown, ChevronRight, Lock } from "lucide-react"
+import { CLASSIFICATION_META, type FieldClassification } from "@/lib/schema/fieldClassification"
+
+interface FieldSectionHeaderProps {
+    classification: FieldClassification
+    fieldCount: number
+    expanded: boolean
+    onToggle: () => void
+    isFirst?: boolean
+}
+
+export const FieldSectionHeader = ({
+    classification,
+    fieldCount,
+    expanded,
+    onToggle,
+    isFirst = false,
+}: FieldSectionHeaderProps) => {
+    const meta = CLASSIFICATION_META[classification]
+
+    return (
+        <div className={`${isFirst ? '' : 'border-t border-border mt-2 pt-1.5'}`}>
+            <button
+                onClick={onToggle}
+                className="flex items-center gap-1.5 w-full text-left py-0.5 cursor-pointer hover:bg-muted/50 rounded px-1 transition-colors"
+            >
+                {classification === 'readOnly' ? (
+                    <Lock className="w-2.5 h-2.5 text-muted-foreground/50 shrink-0" />
+                ) : (
+                    <span className={`inline-block w-1.5 h-1.5 rounded-full ${meta.dotColor} shrink-0`} />
+                )}
+                <span className={`text-[10px] font-medium ${meta.colorClass}`}>
+                    {meta.label}
+                </span>
+                <span className="text-[9px] text-muted-foreground/60 bg-muted rounded-full px-1.5 py-px">
+                    {fieldCount}
+                </span>
+                <span className="ml-auto">
+                    {expanded ? (
+                        <ChevronDown className="w-3 h-3 text-muted-foreground/50" />
+                    ) : (
+                        <ChevronRight className="w-3 h-3 text-muted-foreground/50" />
+                    )}
+                </span>
+            </button>
+        </div>
+    )
+}

--- a/src/components/flow/nodes/fields/field.types.ts
+++ b/src/components/flow/nodes/fields/field.types.ts
@@ -1,4 +1,5 @@
 import { Schema, FlowEdge } from "@/types"
+import type { FieldClassification } from "@/lib/schema/fieldClassification"
 
 export interface BaseFieldProps {
     label: string
@@ -10,6 +11,8 @@ export interface BaseFieldProps {
     mode?: 'kind' | 'objectRef'
     readOnly?: boolean
     kind?: string
+    classification?: FieldClassification
+    parentPath?: string
     onChange: (path: string, val: unknown) => void
     onRemove?: () => void
     depth?: number

--- a/src/components/flow/nodes/fields/field.use-connection.hook.ts
+++ b/src/components/flow/nodes/fields/field.use-connection.hook.ts
@@ -40,6 +40,11 @@ export const useFieldConnection = ({
 
             const selfId = `${nodeId}.${label}`
             publish(selfId, `#ref-${refValue}`)
+
+            return () => {
+                onChange(path, undefined)
+                publish(selfId, undefined)
+            }
         }
     }, [isConnected, edge?.source, edge?.sourceHandle, nodeId, label, path, onChange, valueType])
 

--- a/src/data/field-recommendations.ts
+++ b/src/data/field-recommendations.ts
@@ -1,0 +1,308 @@
+export interface KindRecommendations {
+    recommended: Record<string, string>
+    common: string[]
+}
+
+/**
+ * Top-level field recommendations per kind.
+ * Keys are lowercase kind names.
+ */
+export const FIELD_RECOMMENDATIONS: Record<string, KindRecommendations> = {
+    deployment: {
+        recommended: {
+            metadata: 'Labels and namespace identify and organize your deployment. Namespace isolation prevents cross-team conflicts.',
+            spec: 'The spec defines replicas, update strategy, and the pod template — the core of what your deployment runs.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    service: {
+        recommended: {
+            metadata: 'Service names become DNS entries in the cluster. Labels and namespace determine discoverability.',
+            spec: 'Defines the selector, ports, and service type. The selector must match pod labels to route traffic correctly.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    pod: {
+        recommended: {
+            metadata: 'Pod metadata provides identity and labeling. Labels enable service discovery and scheduling constraints.',
+            spec: 'Defines containers, volumes, and scheduling. This is the fundamental unit of execution in Kubernetes.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    statefulset: {
+        recommended: {
+            metadata: 'StatefulSet names determine stable pod identities (name-0, name-1, etc.). Namespace prevents collisions.',
+            spec: 'Defines replicas, volume claim templates, and update strategy. Pods get stable storage and ordered deployment.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    daemonset: {
+        recommended: {
+            metadata: 'DaemonSet metadata controls which nodes run the pod. Labels enable monitoring and log collection targeting.',
+            spec: 'Defines the pod template and update strategy. Runs one pod per matching node automatically.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    configmap: {
+        recommended: {
+            metadata: 'ConfigMap names are referenced by pods. Namespace scoping prevents accidental cross-environment data sharing.',
+        },
+        common: ['apiVersion', 'kind', 'data'],
+    },
+    secret: {
+        recommended: {
+            metadata: 'Secret names are referenced by pods and service accounts. Namespace isolation is critical for security.',
+        },
+        common: ['apiVersion', 'kind', 'data', 'type'],
+    },
+    ingress: {
+        recommended: {
+            metadata: 'Ingress annotations configure the controller (TLS, rate limiting, rewrites). Different controllers use different annotations.',
+            spec: 'Defines routing rules, TLS configuration, and the default backend. Maps external traffic to internal services.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    cronjob: {
+        recommended: {
+            metadata: 'CronJob names appear in spawned Job names. Clear naming helps track scheduled workload execution.',
+            spec: 'Defines the schedule, concurrency policy, and job template. Controls when and how jobs are created.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    job: {
+        recommended: {
+            metadata: 'Job names identify batch workloads. Labels help track completion and debug failures.',
+            spec: 'Defines parallelism, completions, and the pod template. Controls how the batch workload executes.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    persistentvolumeclaim: {
+        recommended: {
+            metadata: 'PVC names are referenced by pods for volume mounts. Namespace determines which pods can access the storage.',
+            spec: 'Defines storage class, access modes, and size. Determines what kind of storage is provisioned.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    horizontalpodautoscaler: {
+        recommended: {
+            metadata: 'HPA names identify the autoscaling policy. Labels help organize autoscaling across deployments.',
+            spec: 'Defines min/max replicas, target CPU/memory, and the scale target. Controls automatic pod scaling.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    namespace: {
+        recommended: {
+            metadata: 'Namespace names define isolation boundaries. Labels enable policy enforcement and resource quota targeting.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    serviceaccount: {
+        recommended: {
+            metadata: 'ServiceAccount names are referenced by pods. Namespace determines which pods can use this identity.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+    role: {
+        recommended: {
+            metadata: 'Role names are referenced by RoleBindings. Namespace limits the scope of permissions granted.',
+        },
+        common: ['apiVersion', 'kind', 'rules'],
+    },
+    rolebinding: {
+        recommended: {
+            metadata: 'RoleBinding names identify the permission grant. Namespace limits where the binding applies.',
+        },
+        common: ['apiVersion', 'kind', 'roleRef', 'subjects'],
+    },
+    clusterrole: {
+        recommended: {
+            metadata: 'ClusterRole names are referenced by ClusterRoleBindings. These permissions apply cluster-wide.',
+        },
+        common: ['apiVersion', 'kind', 'rules'],
+    },
+    clusterrolebinding: {
+        recommended: {
+            metadata: 'ClusterRoleBinding names identify cluster-wide permission grants. Be cautious — these affect all namespaces.',
+        },
+        common: ['apiVersion', 'kind', 'roleRef', 'subjects'],
+    },
+    networkpolicy: {
+        recommended: {
+            metadata: 'NetworkPolicy names identify traffic rules. Labels and namespace determine which pods are affected.',
+            spec: 'Defines ingress/egress rules and pod selectors. Controls network traffic between pods and external endpoints.',
+        },
+        common: ['apiVersion', 'kind'],
+    },
+}
+
+/**
+ * Nested field recommendations keyed by "kind.parentPath".
+ * Used when classifying fields inside ObjectRefNodes.
+ * A special "*" kind prefix applies to all kinds (shared metadata fields, etc.).
+ */
+export const NESTED_FIELD_RECOMMENDATIONS: Record<string, KindRecommendations> = {
+    // ── Shared metadata fields (apply to all kinds) ──
+    '*.metadata': {
+        recommended: {
+            namespace: 'Without a namespace, resources land in "default". Explicit namespaces prevent accidental cross-environment deployments.',
+            labels: 'Labels are the primary mechanism for selecting and grouping resources. Services, HPAs, and network policies all rely on label selectors.',
+        },
+        common: ['name', 'annotations'],
+    },
+
+    // ── Deployment ──
+    'deployment.spec': {
+        recommended: {
+            replicas: 'Controls how many pod instances run. Set this to match your availability requirements.',
+            selector: 'The selector determines which pods belong to this deployment. Must match the template labels exactly.',
+            template: 'The pod template defines what each replica runs — containers, volumes, and scheduling rules.',
+            strategy: 'The update strategy (RollingUpdate or Recreate) controls how new versions are rolled out with minimal downtime.',
+        },
+        common: ['minReadySeconds', 'revisionHistoryLimit', 'progressDeadlineSeconds'],
+    },
+    'deployment.spec.template': {
+        recommended: {
+            metadata: 'Template metadata must include labels that match the selector. These labels are how the deployment finds its pods.',
+            spec: 'The pod spec defines containers, volumes, security context, and scheduling. This is the core of your workload.',
+        },
+        common: [],
+    },
+    'deployment.spec.template.spec': {
+        recommended: {
+            containers: 'The containers array defines what runs in each pod. At least one container is required.',
+            serviceAccountName: 'Assigns a specific identity to pods. Without this, pods use the "default" service account which may have too many or too few permissions.',
+        },
+        common: ['volumes', 'imagePullSecrets', 'nodeSelector', 'tolerations', 'affinity', 'restartPolicy'],
+    },
+
+    // ── Service ──
+    'service.spec': {
+        recommended: {
+            selector: 'The selector determines which pods receive traffic. Must match pod labels exactly or no endpoints will be created.',
+            ports: 'Defines which ports are exposed and how they map to container ports. At least one port is required.',
+            type: 'The service type (ClusterIP, NodePort, LoadBalancer) controls how the service is exposed. ClusterIP is the default for internal traffic.',
+        },
+        common: ['clusterIP', 'sessionAffinity', 'externalTrafficPolicy'],
+    },
+
+    // ── StatefulSet ──
+    'statefulset.spec': {
+        recommended: {
+            replicas: 'Controls the number of stateful pod replicas. Each gets a stable hostname and persistent storage.',
+            selector: 'Must match template labels. Changing this after creation requires deleting and recreating the StatefulSet.',
+            template: 'Defines the pod template. Each pod gets a stable identity (name-0, name-1, etc.).',
+            serviceName: 'The headless service that provides DNS entries for each pod. Required for stable network identities.',
+            volumeClaimTemplates: 'Defines persistent volume claims for each pod. Each replica gets its own dedicated storage.',
+        },
+        common: ['updateStrategy', 'podManagementPolicy', 'minReadySeconds', 'revisionHistoryLimit'],
+    },
+    'statefulset.spec.template': {
+        recommended: {
+            metadata: 'Template labels must match the selector. These labels provide stable identity for each pod.',
+            spec: 'The pod spec defines containers, volumes, and scheduling for each stateful replica.',
+        },
+        common: [],
+    },
+    'statefulset.spec.template.spec': {
+        recommended: {
+            containers: 'At least one container is required. Stateful workloads typically need careful resource and volume configuration.',
+            serviceAccountName: 'Assigns identity for RBAC. Stateful workloads often need specific permissions for storage operations.',
+        },
+        common: ['volumes', 'imagePullSecrets', 'nodeSelector', 'tolerations', 'affinity', 'restartPolicy'],
+    },
+
+    // ── DaemonSet ──
+    'daemonset.spec': {
+        recommended: {
+            selector: 'Determines which pods belong to this DaemonSet. Must match template labels.',
+            template: 'The pod template runs on every matching node. DaemonSets are ideal for logging, monitoring, and networking agents.',
+        },
+        common: ['updateStrategy', 'minReadySeconds', 'revisionHistoryLimit'],
+    },
+    'daemonset.spec.template': {
+        recommended: {
+            metadata: 'Template labels must match the selector.',
+            spec: 'Defines the pod spec for each node. DaemonSet pods often need host networking or privileged access.',
+        },
+        common: [],
+    },
+    'daemonset.spec.template.spec': {
+        recommended: {
+            containers: 'The containers that run on every node. DaemonSet containers typically collect logs, metrics, or manage networking.',
+            serviceAccountName: 'DaemonSet pods often need elevated permissions for host-level operations.',
+        },
+        common: ['volumes', 'hostNetwork', 'nodeSelector', 'tolerations', 'affinity', 'restartPolicy'],
+    },
+
+    // ── CronJob ──
+    'cronjob.spec': {
+        recommended: {
+            schedule: 'Cron expression defining when jobs run. Format: "minute hour day month weekday" (e.g., "0 2 * * *" for daily at 2 AM).',
+            jobTemplate: 'The job template defines what runs on each scheduled execution.',
+            concurrencyPolicy: 'Controls overlap behavior (Allow, Forbid, Replace). Prevents resource waste from overlapping jobs.',
+        },
+        common: ['startingDeadlineSeconds', 'successfulJobsHistoryLimit', 'failedJobsHistoryLimit', 'suspend'],
+    },
+
+    // ── Job ──
+    'job.spec': {
+        recommended: {
+            template: 'The pod template defines what the job runs. Jobs create pods that run to completion.',
+        },
+        common: ['completions', 'parallelism', 'backoffLimit', 'activeDeadlineSeconds', 'ttlSecondsAfterFinished'],
+    },
+
+    // ── Ingress ──
+    'ingress.spec': {
+        recommended: {
+            rules: 'Defines host and path-based routing rules. Maps external URLs to internal services.',
+            tls: 'TLS configuration for HTTPS. References a Secret containing the certificate and key.',
+        },
+        common: ['ingressClassName', 'defaultBackend'],
+    },
+
+    // ── PersistentVolumeClaim ──
+    'persistentvolumeclaim.spec': {
+        recommended: {
+            accessModes: 'Defines how the volume can be accessed (ReadWriteOnce, ReadOnlyMany, ReadWriteMany). Must match workload requirements.',
+            resources: 'Specifies the storage size request. The cluster provisions at least this much storage.',
+        },
+        common: ['storageClassName', 'volumeMode', 'volumeName'],
+    },
+
+    // ── HorizontalPodAutoscaler ──
+    'horizontalpodautoscaler.spec': {
+        recommended: {
+            scaleTargetRef: 'References the Deployment or StatefulSet to scale. Must match the target resource exactly.',
+            minReplicas: 'Minimum number of replicas to maintain. Prevents scaling to zero during low traffic.',
+            maxReplicas: 'Maximum number of replicas. Prevents runaway scaling and unexpected costs.',
+            metrics: 'Defines the scaling triggers (CPU, memory, custom metrics). Controls when pods are added or removed.',
+        },
+        common: ['behavior'],
+    },
+
+    // ── NetworkPolicy ──
+    'networkpolicy.spec': {
+        recommended: {
+            podSelector: 'Selects which pods this policy applies to. An empty selector applies to all pods in the namespace.',
+            policyTypes: 'Specifies whether the policy applies to Ingress, Egress, or both.',
+        },
+        common: ['ingress', 'egress'],
+    },
+
+    // ── Role / ClusterRole ──
+    '*.rules': {
+        recommended: {},
+        common: ['apiGroups', 'resources', 'verbs', 'resourceNames'],
+    },
+
+    // ── RoleBinding / ClusterRoleBinding ──
+    '*.roleRef': {
+        recommended: {
+            apiGroup: 'The API group of the role being referenced (usually "rbac.authorization.k8s.io").',
+            kind: 'Whether this references a Role or ClusterRole.',
+            name: 'The name of the Role or ClusterRole to bind.',
+        },
+        common: [],
+    },
+}

--- a/src/lib/schema/fieldClassification.ts
+++ b/src/lib/schema/fieldClassification.ts
@@ -1,0 +1,164 @@
+import { FIELD_RECOMMENDATIONS, NESTED_FIELD_RECOMMENDATIONS } from '@/data/field-recommendations'
+import type { Schema } from '@/types'
+
+export type FieldClassification = 'required' | 'recommended' | 'common' | 'optional' | 'readOnly'
+
+export const CLASSIFICATION_META: Record<FieldClassification, {
+    label: string
+    colorClass: string
+    dotColor: string
+    description: string
+    defaultExpanded: boolean
+}> = {
+    required: {
+        label: 'Required',
+        colorClass: 'text-red-500',
+        dotColor: 'bg-red-500',
+        description: 'Must be set for a valid resource',
+        defaultExpanded: true,
+    },
+    recommended: {
+        label: 'Recommended',
+        colorClass: 'text-amber-500',
+        dotColor: 'bg-amber-500',
+        description: 'Strongly recommended for production use',
+        defaultExpanded: true,
+    },
+    common: {
+        label: 'Common',
+        colorClass: 'text-muted-foreground',
+        dotColor: 'bg-muted-foreground',
+        description: 'Commonly configured fields',
+        defaultExpanded: true,
+    },
+    optional: {
+        label: 'Optional',
+        colorClass: 'text-muted-foreground/50',
+        dotColor: 'bg-muted-foreground/50',
+        description: 'Optional configuration',
+        defaultExpanded: false,
+    },
+    readOnly: {
+        label: 'Read-Only',
+        colorClass: 'text-muted-foreground/50',
+        dotColor: 'bg-muted-foreground/50',
+        description: 'Set by the system, not user-configurable',
+        defaultExpanded: false,
+    },
+}
+
+export const GLOBAL_READ_ONLY_FIELDS = new Set([
+    'status',
+    'metadata.uid',
+    'metadata.resourceVersion',
+    'metadata.generation',
+    'metadata.creationTimestamp',
+    'metadata.deletionTimestamp',
+    'metadata.deletionGracePeriodSeconds',
+    'metadata.selfLink',
+    'metadata.managedFields',
+])
+
+export const TOP_LEVEL_READ_ONLY = new Set(['status'])
+
+export function isReadOnlyField(fieldName: string, _kind: string, parentPath?: string): boolean {
+    if (TOP_LEVEL_READ_ONLY.has(fieldName) && !parentPath) return true
+    const fullPath = parentPath ? `${parentPath}.${fieldName}` : fieldName
+    return GLOBAL_READ_ONLY_FIELDS.has(fullPath)
+}
+
+/**
+ * Look up nested recommendations for a field.
+ * Checks kind-specific key first (e.g. "deployment.spec"), then wildcard (e.g. "*.metadata").
+ */
+function getNestedRecommendations(kind: string, parentPath: string) {
+    const kindKey = kind.toLowerCase()
+    return NESTED_FIELD_RECOMMENDATIONS[`${kindKey}.${parentPath}`]
+        ?? NESTED_FIELD_RECOMMENDATIONS[`*.${parentPath}`]
+        ?? null
+}
+
+export function classifyField(
+    fieldName: string,
+    kind: string,
+    schemaRequiredArray: string[],
+    parentPath?: string,
+): FieldClassification {
+    // 1. Top-level read-only
+    if (!parentPath && TOP_LEVEL_READ_ONLY.has(fieldName)) return 'readOnly'
+
+    // 2. Global read-only by full path
+    const fullPath = parentPath ? `${parentPath}.${fieldName}` : fieldName
+    if (GLOBAL_READ_ONLY_FIELDS.has(fullPath)) return 'readOnly'
+
+    // 3. Schema required
+    if (schemaRequiredArray.includes(fieldName)) return 'required'
+
+    // 4. Per-kind recommendations — nested or top-level
+    if (parentPath) {
+        const nestedRecs = getNestedRecommendations(kind, parentPath)
+        if (nestedRecs) {
+            if (nestedRecs.recommended[fieldName]) return 'recommended'
+            if (nestedRecs.common.includes(fieldName)) return 'common'
+        }
+    } else {
+        const kindKey = kind.toLowerCase()
+        const recs = FIELD_RECOMMENDATIONS[kindKey]
+        if (recs) {
+            if (recs.recommended[fieldName]) return 'recommended'
+            if (recs.common.includes(fieldName)) return 'common'
+        }
+    }
+
+    // 5. Default
+    return 'optional'
+}
+
+export function classifyFields(
+    schemaProperties: Record<string, Schema> | undefined,
+    kind: string,
+    schemaRequiredArray: string[],
+    parentPath?: string,
+): Map<string, FieldClassification> {
+    const map = new Map<string, FieldClassification>()
+    if (!schemaProperties) return map
+    for (const fieldName of Object.keys(schemaProperties)) {
+        map.set(fieldName, classifyField(fieldName, kind, schemaRequiredArray, parentPath))
+    }
+    return map
+}
+
+const CLASSIFICATION_ORDER: FieldClassification[] = ['required', 'recommended', 'common', 'optional', 'readOnly']
+
+export function groupFieldsByClassification(
+    fieldEntries: [string, Schema][],
+    classifications: Map<string, FieldClassification>,
+): { classification: FieldClassification; label: string; fields: [string, Schema][] }[] {
+    const groups = new Map<FieldClassification, [string, Schema][]>()
+
+    for (const entry of fieldEntries) {
+        const cls = classifications.get(entry[0]) ?? 'optional'
+        if (!groups.has(cls)) groups.set(cls, [])
+        groups.get(cls)!.push(entry)
+    }
+
+    return CLASSIFICATION_ORDER
+        .filter((cls) => groups.has(cls))
+        .map((cls) => ({
+            classification: cls,
+            label: CLASSIFICATION_META[cls].label,
+            fields: groups.get(cls)!,
+        }))
+}
+
+export function getFieldEducation(fieldName: string, kind: string, parentPath?: string): string | null {
+    if (parentPath) {
+        const nestedRecs = getNestedRecommendations(kind, parentPath)
+        if (nestedRecs) return nestedRecs.recommended[fieldName] ?? null
+    } else {
+        const kindKey = kind.toLowerCase()
+        const recs = FIELD_RECOMMENDATIONS[kindKey]
+        if (recs) return recs.recommended[fieldName] ?? null
+    }
+    return null
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Schema {
   items?: Schema;
   additionalProperties?: boolean | Schema;
   description?: string;
+  required?: string[];
 }
 
 // Plugin slot entry — tracks a plugin connected to a target node
@@ -23,6 +24,7 @@ export interface BaseNodeData extends Record<string, unknown> {
   pluginSlots?: PluginSlotEntry[];
   editing?: boolean;
   sourceFile?: string;
+  showReadOnlyFields?: boolean;
 }
 
 export interface KindNodeData extends BaseNodeData {


### PR DESCRIPTION
## Summary
- Introduces a field classification engine that categorizes schema fields as required, recommended, common, optional, or read-only with visual indicators and collapsible section headers
- Adds curated educational recommendations for 19+ K8s resource kinds with nested path support (deployment.spec, *.metadata, etc.) and "Why this matters" tooltips
- Hides read-only fields (status, metadata.uid, etc.) by default with a context menu toggle, adds grouped Add-Field dropdowns in ObjectRefNode, and an info-level warning for missing recommended fields
- Fixes stale `#ref-` values not being cleaned up when an ObjectRefNode is deleted

## Test plan
- [ ] Open editor with a Deployment template — confirm `status` field is hidden by default
- [ ] Right-click node → "Show Read-Only Fields" → confirm `status` appears grayed with lock icon
- [ ] Confirm fields are grouped into Required, Recommended, Common, Optional sections with collapsible headers
- [ ] Hover over a recommended field label → confirm tooltip shows "Why this matters" educational text
- [ ] Open an ObjectRefNode "Add Field" dropdown → confirm fields grouped by classification with colored dots
- [ ] Check warnings sidebar → confirm info-level "Missing recommended fields" warning appears
- [ ] Create a status ObjectRefNode, then delete it → confirm the empty `status: {}` is removed
- [ ] Run `npm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)